### PR TITLE
Add ConfigureAwait(false) for ConfigurationProvider

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -26,18 +26,18 @@ namespace Kralizek.Extensions.Configuration.Internal
 
         public override void Load()
         {
-            LoadAsync().Wait();
+            LoadAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         async Task LoadAsync()
         {
-            var allSecrets = await FetchAllSecretsAsync();
+            var allSecrets = await FetchAllSecretsAsync().ConfigureAwait(false);
 
             foreach (var secret in allSecrets)
             {
                 if (!Options.SecretFilter(secret)) continue;
 
-                var secretValue = await Client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = secret.ARN });
+                var secretValue = await Client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = secret.ARN }).ConfigureAwait(false);
 
                 var secretString = secretValue.SecretString;
 
@@ -102,7 +102,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 
                 var request = new ListSecretsRequest() { NextToken = nextToken };
 
-                response = await Client.ListSecretsAsync(request);
+                response = await Client.ListSecretsAsync(request).ConfigureAwait(false);
 
                 result.AddRange(response.SecretList);
 

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Kralizek.Extensions.Configuration.AWSSecretsManager</PackageId>
     <Description>AWS Secrets Manager configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
-    <PackageVersion>1.0.0-alpha-1</PackageVersion>
+    <PackageVersion>1.0.0-alpha-2</PackageVersion>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Kralizek/AWSSecretsManagerConfigurationExtensions/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Kralizek/AWSSecretsManagerConfigurationExtensions</PackageProjectUrl>
     <PackageTags>dotnet-standard;aws;aws-secrets-manager;</PackageTags>


### PR DESCRIPTION
Fixes #5

- Add `ConfigureAwait(false)` to async calls
- Switch to `.GetAwaiter().GetResult()` instead of `.Wait()`