### PR TITLE
added configuration method to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ builder.AddSecretsManager(configurator: options =>
 
 You can see an example [here](/samples/Sample5).
 
+### Customizing the AmazonSecretsManagerConfig, for example to use localstack
+
+There are some situations where you might want to customize how the AmazonSecretsManagerConfig is built, for example when you want to use
+[localstack](https://github.com/localstack/localstack) during local development. In those cases, you should customize the ServiceUrl.
+
+```csharp
+
+builder.AddSecretsManager(configurator: options =>
+{
+    options.ConfigureSecretsManagerConfig = c => {
+        c.ServiceUrl = "http://localhost:4584" // The url that's used by localstack
+    };
+});
+
+```
+
 ## Versioning
 
 This library follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) for the public releases (published to the [nuget.org](https://www.nuget.org/)).

--- a/SecretsManager.v3.ncrunchsolution
+++ b/SecretsManager.v3.ncrunchsolution
@@ -1,6 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <AllowParallelTestExecution>True</AllowParallelTestExecution>
-    <SolutionConfigured>True</SolutionConfigured>
-  </Settings>
-</SolutionConfiguration>

--- a/SecretsManager.v3.ncrunchsolution
+++ b/SecretsManager.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 
 namespace Kralizek.Extensions.Configuration.Internal {
@@ -7,5 +8,7 @@ namespace Kralizek.Extensions.Configuration.Internal {
         public Func<SecretListEntry, bool> SecretFilter { get; set; } = secret => true;
 
         public Func<SecretListEntry, string, string> KeyGenerator { get; set; } = (secret, key) => key;
+
+        public Action<AmazonSecretsManagerConfig> ConfigureSecretsManagerConfig { get; set; } = _ => { };
     }
 }

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationSource.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationSource.cs
@@ -23,27 +23,27 @@ namespace Kralizek.Extensions.Configuration.Internal
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
             var client = CreateClient();
+            
             return new SecretsManagerConfigurationProvider(client, Options);
         }
 
         private IAmazonSecretsManager CreateClient()
         {
-            if (Credentials == null && Region == null)
+            var clientConfig = new AmazonSecretsManagerConfig
             {
-                return new AmazonSecretsManagerClient();
-            }
+                RegionEndpoint = Region
+            };
+
+
+            Options.ConfigureSecretsManagerConfig(clientConfig);
 
             if (Credentials == null)
             {
-                return new AmazonSecretsManagerClient(Region);
+                return new AmazonSecretsManagerClient(clientConfig);
             }
 
-            if (Region == null)
-            {
-                return new AmazonSecretsManagerClient(Credentials);
-            }
 
-            return new AmazonSecretsManagerClient(Credentials, Region);
+            return new AmazonSecretsManagerClient(Credentials, clientConfig);
         }
     }
 

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationSourceTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationSourceTests.cs
@@ -1,4 +1,5 @@
 using Amazon.Runtime;
+using Amazon.SecretsManager;
 using Kralizek.Extensions.Configuration.Internal;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
@@ -40,5 +41,29 @@ namespace Tests.Internal
             Assert.That(provider, Is.Not.Null);
             Assert.That(provider, Is.InstanceOf<SecretsManagerConfigurationProvider>());
         }
+
+        [Test, AutoMoqData]
+        public void Build_invokes_config_client_method(IConfigurationBuilder configurationBuilder)
+        {
+            bool configInvoked = false;
+            AmazonSecretsManagerConfig usedConfig = null;
+            var sut = new SecretsManagerConfigurationSource(options: new SecretsManagerConfigurationProviderOptions()
+            {
+                ConfigureSecretsManagerConfig = c =>
+                {
+                    usedConfig = c;
+                    configInvoked = true;
+                }
+            });
+            
+
+            var provider = sut.Build(configurationBuilder);
+
+            Assert.That(configInvoked, Is.True);
+            Assert.That(usedConfig, Is.Not.Null);
+            
+        }
+
+
     }
 }

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/SecretsManagerExtensionsTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/SecretsManagerExtensionsTests.cs
@@ -70,5 +70,6 @@ namespace Tests
 
             configurationBuilder.Verify(m => m.Add(It.Is<SecretsManagerConfigurationSource>(s => s.Region == region)));
         }
+
     }
 }


### PR DESCRIPTION
Nice work on your library. 

I wanted to use it in combination with localstack (https://github.com/localstack/localstack), but I didn't find a clean way to set the client url. 

With this PR, i'm adding that support, by adding an additional configuration action to the options. 

```csharp

builder.AddSecretsManager(configurator: options =>
{
    options.ConfigureSecretsManagerConfig = c => {
        c.ServiceUrl = "http://localhost:4584" // The url that's used by localstack
    };
});

```

Hope you find it useful.