### PR TITLE
Add more info for missing secret values

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/MissingSecretValueException.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/MissingSecretValueException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Kralizek.Extensions.Configuration.Internal
+{
+    public class MissingSecretValueException : Exception
+    {
+        public MissingSecretValueException(string errorMessage, Exception exception) : base(errorMessage, exception)
+        {
+            
+        }
+    }
+}

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/MissingSecretValueException.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/MissingSecretValueException.cs
@@ -4,9 +4,14 @@ namespace Kralizek.Extensions.Configuration.Internal
 {
     public class MissingSecretValueException : Exception
     {
-        public MissingSecretValueException(string errorMessage, Exception exception) : base(errorMessage, exception)
+        public MissingSecretValueException(string errorMessage, string secretName, string secretArn, Exception exception) : base(errorMessage, exception)
         {
-            
+            this.SecretName = secretName;
+            this.SecretArn = secretArn;
         }
+
+        public string SecretArn { get; set; }
+
+        public string SecretName { get; set; }
     }
 }

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -32,31 +32,39 @@ namespace Kralizek.Extensions.Configuration.Internal
 
             foreach (var secret in allSecrets)
             {
-                if (!Options.SecretFilter(secret)) continue;
-
-                var secretValue = await Client.GetSecretValueAsync(new GetSecretValueRequest {SecretId = secret.ARN}).ConfigureAwait(false);
-
-                var secretString = secretValue.SecretString;
-
-                if (secretString != null)
+                try
                 {
-                    if (IsJson(secretString))
+                    if (!Options.SecretFilter(secret)) continue;
+
+                    var secretValue = await Client.GetSecretValueAsync(new GetSecretValueRequest {SecretId = secret.ARN}).ConfigureAwait(false);
+
+                    var secretString = secretValue.SecretString;
+
+                    if (secretString != null)
                     {
-                        var obj = JObject.Parse(secretString);
-
-                        var values = ExtractValues(obj, secret.Name);
-
-                        foreach (var value in values)
+                        if (IsJson(secretString))
                         {
-                            var key = Options.KeyGenerator(secret, value.key);
-                            Set(key, value.value);
+                            var obj = JObject.Parse(secretString);
+
+                            var values = ExtractValues(obj, secret.Name);
+
+                            foreach (var value in values)
+                            {
+                                var key = Options.KeyGenerator(secret, value.key);
+                                Set(key, value.value);
+                            }
+                        }
+                        else
+                        {
+                            var key = Options.KeyGenerator(secret, secret.Name);
+                            Set(key, secretString);
                         }
                     }
-                    else
-                    {
-                        var key = Options.KeyGenerator(secret, secret.Name);
-                        Set(key, secretString);
-                    }
+                }
+                catch (ResourceNotFoundException e)
+                {
+                    throw new MissingSecretValueException($"Error retrieving secret value (Secret: {secret.Name} Arn: {secret.ARN})", e);
+
                 }
             }
         }

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -63,7 +63,7 @@ namespace Kralizek.Extensions.Configuration.Internal
                 }
                 catch (ResourceNotFoundException e)
                 {
-                    throw new MissingSecretValueException($"Error retrieving secret value (Secret: {secret.Name} Arn: {secret.ARN})", e);
+                    throw new MissingSecretValueException($"Error retrieving secret value (Secret: {secret.Name} Arn: {secret.ARN})", secret.Name, secret.ARN, e);
 
                 }
             }


### PR DESCRIPTION
When secrets don't have values currently you get a `ResourceNotFoundException` thrown by AWS with no idea what's happening. This catches that exception and throws with information about the secret & arn where the problem exists