### PR TITLE
Add polling to reload configuration upon secrets changes.

### DIFF
--- a/samples/SampleWeb/Program.cs
+++ b/samples/SampleWeb/Program.cs
@@ -21,7 +21,10 @@ namespace SampleWeb
             WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, config) =>  
                 {
-                    config.AddSecretsManager();
+                    config.AddSecretsManager(configurator: o =>
+                    {
+                        o.PollingInterval = TimeSpan.FromSeconds(10);
+                    });
                 })
                 .UseStartup<Startup>()
                 .Build();

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -10,5 +10,7 @@ namespace Kralizek.Extensions.Configuration.Internal {
         public Func<SecretListEntry, string, string> KeyGenerator { get; set; } = (secret, key) => key;
 
         public Action<AmazonSecretsManagerConfig> ConfigureSecretsManagerConfig { get; set; } = _ => { };
+
+        public TimeSpan? PollingInterval { get; set; }
     }
 }


### PR DESCRIPTION
Heavily inspired by the [AzureKeyVault extension](https://github.com/dotnet/extensions/tree/release/3.1/src/Configuration/Config.AzureKeyVault).

Addresses issue #23.