### PR TITLE
Add support for custom client factory

### DIFF
--- a/SecretsManager.sln
+++ b/SecretsManager.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
@@ -23,6 +23,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample5", "samples\Sample5\Sample5.csproj", "{7756FF98-349B-4E15-82D6-523E8AA59D72}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleWeb", "samples\SampleWeb\SampleWeb.csproj", "{2C9A8D87-1C3E-4F3C-8DDF-E079DD9FBC9B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample6", "samples\Sample6\Sample6.csproj", "{0C856672-08BA-4E06-B69E-0C4526FB8F54}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -130,6 +132,18 @@ Global
 		{2C9A8D87-1C3E-4F3C-8DDF-E079DD9FBC9B}.Release|x64.Build.0 = Release|Any CPU
 		{2C9A8D87-1C3E-4F3C-8DDF-E079DD9FBC9B}.Release|x86.ActiveCfg = Release|Any CPU
 		{2C9A8D87-1C3E-4F3C-8DDF-E079DD9FBC9B}.Release|x86.Build.0 = Release|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Debug|x64.Build.0 = Debug|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Release|x64.ActiveCfg = Release|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Release|x64.Build.0 = Release|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -143,6 +157,7 @@ Global
 		{42B9639F-DE6B-414E-AB8A-C9C26E844DE5} = {101F77F3-9063-4287-AB1D-20DD19F171A6}
 		{7756FF98-349B-4E15-82D6-523E8AA59D72} = {101F77F3-9063-4287-AB1D-20DD19F171A6}
 		{2C9A8D87-1C3E-4F3C-8DDF-E079DD9FBC9B} = {101F77F3-9063-4287-AB1D-20DD19F171A6}
+		{0C856672-08BA-4E06-B69E-0C4526FB8F54} = {101F77F3-9063-4287-AB1D-20DD19F171A6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A1CF3BDB-61B4-458C-960A-25CBC7E5EB83}

--- a/samples/Sample6/Program.cs
+++ b/samples/Sample6/Program.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Amazon;
+using Amazon.SecretsManager;
+using Microsoft.Extensions.Configuration;
+
+namespace Sample5
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var builder = new ConfigurationBuilder();
+
+            /*
+                Uses the specified client factory method
+            */
+            builder.AddSecretsManager(configurator: options =>
+            {
+                options.CreateClient = CreateClient;
+            });
+
+            var configuration = builder.Build();
+
+            Console.WriteLine("Hello World!");
+        }
+
+        private static IAmazonSecretsManager CreateClient()
+        {
+            return new AmazonSecretsManagerClient(RegionEndpoint.EUWest1);
+        }
+    }
+}

--- a/samples/Sample6/Sample6.csproj
+++ b/samples/Sample6/Sample6.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Extensions.Configuration.AWSSecretsManager\Kralizek.Extensions.Configuration.AWSSecretsManager.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -2,7 +2,8 @@ using System;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 
-namespace Kralizek.Extensions.Configuration.Internal {
+namespace Kralizek.Extensions.Configuration.Internal
+{
     public class SecretsManagerConfigurationProviderOptions
     {
         public Func<SecretListEntry, bool> SecretFilter { get; set; } = secret => true;
@@ -10,6 +11,8 @@ namespace Kralizek.Extensions.Configuration.Internal {
         public Func<SecretListEntry, string, string> KeyGenerator { get; set; } = (secret, key) => key;
 
         public Action<AmazonSecretsManagerConfig> ConfigureSecretsManagerConfig { get; set; } = _ => { };
+
+        public Func<IAmazonSecretsManager> CreateClient { get; set; }
 
         public TimeSpan? PollingInterval { get; set; }
     }

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationSource.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationSource.cs
@@ -29,11 +29,15 @@ namespace Kralizek.Extensions.Configuration.Internal
 
         private IAmazonSecretsManager CreateClient()
         {
+            if (Options.CreateClient != null)
+            {
+                return Options.CreateClient();
+            }
+
             var clientConfig = new AmazonSecretsManagerConfig
             {
                 RegionEndpoint = Region
             };
-
 
             Options.ConfigureSecretsManagerConfig(clientConfig);
 
@@ -41,7 +45,6 @@ namespace Kralizek.Extensions.Configuration.Internal
             {
                 return new AmazonSecretsManagerClient(clientConfig);
             }
-
 
             return new AmazonSecretsManagerClient(Credentials, clientConfig);
         }

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/AutoMoqDataAttribute.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/AutoMoqDataAttribute.cs
@@ -3,6 +3,7 @@ using System.Text;
 using AutoFixture.NUnit3;
 using AutoFixture;
 using AutoFixture.AutoMoq;
+using Kralizek.Extensions.Configuration.Internal;
 
 namespace Tests
 {
@@ -13,7 +14,22 @@ namespace Tests
         private static IFixture CreateFixture()
         {
             IFixture fixture = new Fixture();
-            fixture.Customize(new AutoMoqCustomization { GenerateDelegates = true });
+            
+            fixture.Customize(new AutoMoqCustomization 
+            {
+                GenerateDelegates = true
+            });
+
+            fixture.Customize<SecretsManagerConfigurationProviderOptions>(o => o.OmitAutoProperties());
+
+            fixture.Customize<MemoryStream>(c =>
+            {
+                return c.FromFactory((string str) =>
+                {
+                    var bytes = Encoding.UTF8.GetBytes(str);
+                    return new MemoryStream(bytes);
+                }).OmitAutoProperties();
+            });
 
             return fixture;
         }

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/ConfigurationProviderExtensions.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/ConfigurationProviderExtensions.cs
@@ -26,6 +26,7 @@ namespace Tests
     }
 
     [TestFixture]
+    [TestOf(typeof(ConfigurationProviderExtensions))]
     public class ConfigurationProviderExtensionsTests
     {
         [Test, AutoMoqData]

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -1,6 +1,7 @@
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 using AutoFixture;
+using AutoFixture.NUnit3;
 using Kralizek.Extensions.Configuration.Internal;
 using Moq;
 using Newtonsoft.Json;
@@ -16,37 +17,11 @@ using Tests.Types;
 namespace Tests.Internal
 {
     [TestFixture]
+    [TestOf(typeof(SecretsManagerConfigurationProvider))]
     public class SecretsManagerConfigurationProviderTests
     {
-        private IFixture fixture;
-        private Mock<IAmazonSecretsManager> mockSecretsManager;
-
-        [SetUp]
-        public void Initialize()
-        {
-            fixture = new Fixture();
-
-            fixture.Customize<MemoryStream>(c =>
-            {
-                return c.FromFactory((string str) =>
-                {
-                    var bytes = Encoding.UTF8.GetBytes(str);
-                    return new MemoryStream(bytes);
-                }).OmitAutoProperties();
-            });
-
-            mockSecretsManager = new Mock<IAmazonSecretsManager>();
-        }
-
-        private SecretsManagerConfigurationProvider CreateSystemUnderTest(SecretsManagerConfigurationProviderOptions options = null)
-        {
-            options = options ?? new SecretsManagerConfigurationProviderOptions();
-
-            return new SecretsManagerConfigurationProvider(mockSecretsManager.Object, options);
-        }
-
         [Test, AutoMoqData]
-        public void Simple_values_in_string_can_be_handled(SecretListEntry testEntry)
+        public void Simple_values_in_string_can_be_handled(SecretListEntry testEntry, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -58,11 +33,9 @@ namespace Tests.Internal
                                                 .Without(p => p.SecretBinary)
                                                 .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
-
-            var sut = CreateSystemUnderTest();
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
 
             sut.Load();
 
@@ -70,7 +43,7 @@ namespace Tests.Internal
         }
 
         [Test, AutoMoqData]
-        public void Complex_JSON_objects_in_string_can_be_handled(SecretListEntry testEntry, RootObject test)
+        public void Complex_JSON_objects_in_string_can_be_handled(SecretListEntry testEntry, RootObject test, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -82,11 +55,9 @@ namespace Tests.Internal
                                                 .Without(p => p.SecretBinary)
                                                 .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
-
-            var sut = CreateSystemUnderTest();
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
 
             sut.Load();
 
@@ -96,7 +67,7 @@ namespace Tests.Internal
         }
 
         [Test, AutoMoqData]
-        public void Complex_JSON_objects_with_arrays_can_be_handled(SecretListEntry testEntry, RootObjectWithArray test)
+        public void Complex_JSON_objects_with_arrays_can_be_handled(SecretListEntry testEntry, RootObjectWithArray test, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -108,11 +79,9 @@ namespace Tests.Internal
                                                 .Without(p => p.SecretBinary)
                                                 .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
-
-            var sut = CreateSystemUnderTest();
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
 
             sut.Load();
 
@@ -121,7 +90,7 @@ namespace Tests.Internal
         }
 
         [Test, AutoMoqData]
-        public void Array_Of_Complex_JSON_objects_with_arrays_can_be_handled(SecretListEntry testEntry, RootObjectWithArray[] test)
+        public void Array_Of_Complex_JSON_objects_with_arrays_can_be_handled(SecretListEntry testEntry, RootObjectWithArray[] test, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                 .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -133,11 +102,9 @@ namespace Tests.Internal
                 .Without(p => p.SecretBinary)
                 .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
-
-            var sut = CreateSystemUnderTest();
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
 
             sut.Load();
 
@@ -148,7 +115,7 @@ namespace Tests.Internal
         }
 
         [Test, AutoMoqData]
-        public void Values_in_binary_are_ignored(SecretListEntry testEntry)
+        public void Values_in_binary_are_ignored(SecretListEntry testEntry, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -160,11 +127,9 @@ namespace Tests.Internal
                                                 .Without(p => p.SecretString)
                                                 .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
-
-            var sut = CreateSystemUnderTest();
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
 
             sut.Load();
 
@@ -172,31 +137,26 @@ namespace Tests.Internal
         }
 
         [Test, AutoMoqData]
-        public void Secrets_can_be_filtered_out_via_options(SecretListEntry testEntry)
+        public void Secrets_can_be_filtered_out_via_options(SecretListEntry testEntry, [Frozen] IAmazonSecretsManager secretsManager, [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
                                             .With(p => p.NextToken, null)
                                             .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            var options = new SecretsManagerConfigurationProviderOptions
-            {
-                SecretFilter = entry => false
-            };
-
-            var sut = CreateSystemUnderTest(options);
+            options.SecretFilter = entry => false;
 
             sut.Load();
 
-            mockSecretsManager.Verify(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+            Mock.Get(secretsManager).Verify(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>()), Times.Never);
 
             Assert.That(sut.Get(testEntry.Name), Is.Null);
         }
 
         [Test, AutoMoqData]
-        public void Keys_can_be_customized_via_options(SecretListEntry testEntry, string newKey)
+        public void Keys_can_be_customized_via_options(SecretListEntry testEntry, string newKey, [Frozen] IAmazonSecretsManager secretsManager, [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -208,16 +168,11 @@ namespace Tests.Internal
                                                 .Without(p => p.SecretBinary)
                                                 .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
 
-            var options = new SecretsManagerConfigurationProviderOptions
-            {
-                KeyGenerator = (entry, key) => newKey
-            };
-
-            var sut = CreateSystemUnderTest(options);
+            options.KeyGenerator = (entry, key) => newKey;
 
             sut.Load();
 
@@ -226,7 +181,7 @@ namespace Tests.Internal
         }
         
         [Test, AutoMoqData]
-        public void Should_throw_on_missing_secret_value(SecretListEntry testEntry)
+        public void Should_throw_on_missing_secret_value(SecretListEntry testEntry, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut, IFixture fixture)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -234,18 +189,15 @@ namespace Tests.Internal
                                             .Create();
 
            
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).Throws(new ResourceNotFoundException("Oops"));
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).Throws(new ResourceNotFoundException("Oops"));
 
-            var sut = CreateSystemUnderTest();
-
-            Assert.Throws<MissingSecretValueException>(() => sut.Load());
-
+            Assert.That(() => sut.Load(), Throws.TypeOf<MissingSecretValueException>());
         }
 
         [Test, AutoMoqData]
-        public void Should_poll_and_reload_when_secrets_changed(SecretListEntry testEntry, Action<object> changeCallback, object changeCallbackState)
+        public void Should_poll_and_reload_when_secrets_changed(SecretListEntry testEntry, [Frozen] IAmazonSecretsManager secretsManager, [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut, IFixture fixture, Action<object> changeCallback, object changeCallbackState)
         {
             var secretListResponse = fixture.Build<ListSecretsResponse>()
                                             .With(p => p.SecretList, new List<SecretListEntry> { testEntry })
@@ -262,24 +214,23 @@ namespace Tests.Internal
                                                        .Without(p => p.SecretBinary)
                                                        .Create();
 
-            mockSecretsManager.Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(secretListResponse);
 
-            mockSecretsManager.SetupSequence(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>()))
+            Mock.Get(secretsManager).SetupSequence(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>()))
                               .ReturnsAsync(getSecretValueInitialResponse)
                               .ReturnsAsync(getSecretValueUpdatedResponse);
 
-            using (var sut = CreateSystemUnderTest(new SecretsManagerConfigurationProviderOptions { PollingInterval = TimeSpan.FromMilliseconds(100) }))
-            {
-                sut.GetReloadToken().RegisterChangeCallback(changeCallback, changeCallbackState);
+            options.PollingInterval = TimeSpan.FromMilliseconds(100);
 
-                sut.Load();
-                Assert.That(sut.Get(testEntry.Name), Is.EqualTo(getSecretValueInitialResponse.SecretString));
+            sut.GetReloadToken().RegisterChangeCallback(changeCallback, changeCallbackState);
 
-                Thread.Sleep(200);
+            sut.Load();
+            Assert.That(sut.Get(testEntry.Name), Is.EqualTo(getSecretValueInitialResponse.SecretString));
 
-                Mock.Get(changeCallback).Verify(c => c(changeCallbackState));
-                Assert.That(sut.Get(testEntry.Name), Is.EqualTo(getSecretValueUpdatedResponse.SecretString));
-            }
+            Thread.Sleep(200);
+
+            Mock.Get(changeCallback).Verify(c => c(changeCallbackState));
+            Assert.That(sut.Get(testEntry.Name), Is.EqualTo(getSecretValueUpdatedResponse.SecretString));
         }
     }
 }

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/SecretsManagerExtensionsTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/SecretsManagerExtensionsTests.cs
@@ -9,6 +9,7 @@ using Amazon.Runtime;
 namespace Tests
 {
     [TestFixture]
+    [TestOf(typeof(SecretsManagerExtensions))]
     public class SecretsManagerExtensionsTests
     {
         private Mock<IConfigurationBuilder> configurationBuilder;


### PR DESCRIPTION
Users have now the possibility to provide a custom factory method to create a AWS SecretsManager client

Sample of usage:

```csharp
builder.AddSecretsManager(configurator: options =>
{
    options.CreateClient = MyCustomClientFactoryMethod;
});

IAmazonSecretsManager MyCustomClientFactoryMethod() => new AmazonSecretsManagerClient(RegionEndpoint.EUWest1);
```

fixes #25