### PR TITLE
Make dictionary case insensitive

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -127,7 +127,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 
         void SetData(IEnumerable<(string, string)> values, bool triggerReload)
         {
-            Data = values.ToDictionary(x => x.Item1, x => x.Item2);
+            Data = values.ToDictionary(x => x.Item1, x => x.Item2, StringComparer.InvariantCultureIgnoreCase);
             if (triggerReload)
             {
                 OnReload();


### PR DESCRIPTION
Configuration settings keys should be case insensitive. 

https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#configuration-keys-and-values
```
Configuration keys:

    Are case-insensitive. For example, ConnectionString and connectionstring are treated as equivalent keys.

```

Right now, they are not. 

Sorry, haven't had a chance to create a failing test for this.