### PR TITLE
AWSSDK.SecretsManager update to latest version

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
@@ -29,13 +29,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.0" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.5.0.21" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" /> 
   </ItemGroup>
 


### PR DESCRIPTION
Using AWSSDK.Core 3.5.1.19 will throw a warning because AWSSDK.SecretManager isn't up to date. This is just a nuget update. All test passed. 