### PR TITLE
Allow for a list and no searching for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ builder.AddSecretsManager(configurator: options =>
 
 You can see an example [here](/samples/Sample4).
 
+### Defining list of secrets in advance (no list secrets permission required)
+Security best practices sometimes prevent the listing of secrets in a production environment. As a result, a defined list of `ARN` can be provided in lieu of a secrets filter. In this case, the library will only retrieve the secrets whose `ARN` are given. The `.SecretFilter` is ignored.
+
+```csharp
+var acceptedARNs = new[]
+{
+    "MySecretARN1",
+    "MySecretARN2",
+    "MySecretARN3",
+};
+
+builder.AddSecretsManager(configurator: options =>
+{
+    options.AcceptedSecretArns = acceptedARNs;
+});
+```
+
 ### Altering how the values are added to the Configuration
 
 Sometimes we are not in control of the full system. Maybe we are forced to use secrets defined by someone else that uses a different convention.

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -145,7 +145,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 
             var result = new List<SecretListEntry>();
 
-            if (Options.UseDefinedArnList)
+            if (Options.DefinedSecretArns.Count > 0)
             {
                 result.AddRange(Options.DefinedSecretArns.Select(x => new SecretListEntry(){ARN = x}));
                 return result;

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -145,9 +145,9 @@ namespace Kralizek.Extensions.Configuration.Internal
 
             var result = new List<SecretListEntry>();
 
-            if (Options.DefinedSecretArns.Count > 0)
+            if (Options.AcceptedSecretArns.Count > 0)
             {
-                result.AddRange(Options.DefinedSecretArns.Select(x => new SecretListEntry(){ARN = x}));
+                result.AddRange(Options.AcceptedSecretArns.Select(x => new SecretListEntry(){ARN = x}));
                 return result;
             }
 

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -16,7 +16,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 
         public IAmazonSecretsManager Client { get; }
 
-        private HashSet<(string, string)> _loadedValues = new HashSet<(string, string)>();
+        private HashSet<(string, string)> _loadedValues = new();
         private Task? _pollingTask;
         private CancellationTokenSource? _cancellationToken;
 
@@ -37,7 +37,7 @@ namespace Kralizek.Extensions.Configuration.Internal
             return ReloadAsync(cancellationToken);
         }
 
-        async Task LoadAsync()
+        private async Task LoadAsync()
         {
             _loadedValues = await FetchConfigurationAsync(default).ConfigureAwait(false);
             SetData(_loadedValues, triggerReload: false);
@@ -49,7 +49,7 @@ namespace Kralizek.Extensions.Configuration.Internal
             }
         }
 
-        async Task PollForChangesAsync(TimeSpan interval, CancellationToken cancellationToken)
+        private async Task PollForChangesAsync(TimeSpan interval, CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -64,7 +64,7 @@ namespace Kralizek.Extensions.Configuration.Internal
             }
         }
 
-        async Task ReloadAsync(CancellationToken cancellationToken)
+        private async Task ReloadAsync(CancellationToken cancellationToken)
         {
             var oldValues = _loadedValues;
             var newValues = await FetchConfigurationAsync(cancellationToken).ConfigureAwait(false);
@@ -78,7 +78,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 
         private static bool IsJson(string str) => str.StartsWith("[") || str.StartsWith("{");
 
-        IEnumerable<(string key, string value)> ExtractValues(JToken token, string prefix)
+        private static IEnumerable<(string key, string value)> ExtractValues(JToken token, string prefix)
         {
             switch (token)
             {
@@ -130,7 +130,7 @@ namespace Kralizek.Extensions.Configuration.Internal
             }
         }
 
-        void SetData(IEnumerable<(string, string)> values, bool triggerReload)
+        private void SetData(IEnumerable<(string, string)> values, bool triggerReload)
         {
             Data = values.ToDictionary(x => x.Item1, x => x.Item2, StringComparer.InvariantCultureIgnoreCase);
             if (triggerReload)
@@ -139,17 +139,23 @@ namespace Kralizek.Extensions.Configuration.Internal
             }
         }
 
-        async Task<IReadOnlyList<SecretListEntry>> FetchAllSecretsAsync(CancellationToken cancellationToken)
+        private async Task<IReadOnlyList<SecretListEntry>> FetchAllSecretsAsync(CancellationToken cancellationToken)
         {
             var response = default(ListSecretsResponse);
 
             var result = new List<SecretListEntry>();
 
+            if (Options.UseDefinedArnList)
+            {
+                result.AddRange(Options.DefinedSecretArns.Select(x => new SecretListEntry(){ARN = x}));
+                return result;
+            }
+
             do
             {
                 var nextToken = response?.NextToken;
 
-                var request = new ListSecretsRequest() {NextToken = nextToken};
+                var request = new ListSecretsRequest {NextToken = nextToken};
 
                 response = await Client.ListSecretsAsync(request, cancellationToken).ConfigureAwait(false);
 
@@ -158,8 +164,8 @@ namespace Kralizek.Extensions.Configuration.Internal
 
             return result;
         }
-        
-        async Task<HashSet<(string, string)>> FetchConfigurationAsync(CancellationToken cancellationToken)
+
+        private async Task<HashSet<(string, string)>> FetchConfigurationAsync(CancellationToken cancellationToken)
         {
             var secrets = await FetchAllSecretsAsync(cancellationToken).ConfigureAwait(false);
             var configuration = new HashSet<(string, string)>();

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -7,8 +7,8 @@ namespace Kralizek.Extensions.Configuration.Internal
 {
     public class SecretsManagerConfigurationProviderOptions
     {
-        public bool UseDefinedArnList { get; set; } = false;
         public List<string> DefinedSecretArns { get; set; } = new List<string>();
+        
         public Func<SecretListEntry, bool> SecretFilter { get; set; } = _ => true;
 
         public Func<SecretListEntry, string, string> KeyGenerator { get; set; } = (secret, key) => key;

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -7,7 +7,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 {
     public class SecretsManagerConfigurationProviderOptions
     {
-        public List<string> DefinedSecretArns { get; set; } = new List<string>();
+        public List<string> AcceptedSecretArns { get; set; } = new();
         
         public Func<SecretListEntry, bool> SecretFilter { get; set; } = _ => true;
 

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 
@@ -6,7 +7,9 @@ namespace Kralizek.Extensions.Configuration.Internal
 {
     public class SecretsManagerConfigurationProviderOptions
     {
-        public Func<SecretListEntry, bool> SecretFilter { get; set; } = secret => true;
+        public bool UseDefinedArnList { get; set; } = false;
+        public List<string> DefinedSecretArns { get; set; } = new List<string>();
+        public Func<SecretListEntry, bool> SecretFilter { get; set; } = _ => true;
 
         public Func<SecretListEntry, string, string> KeyGenerator { get; set; } = (secret, key) => key;
 

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/ConfigurationProviderExtensions.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/ConfigurationProviderExtensions.cs
@@ -9,7 +9,12 @@ namespace Tests
         {
             var key = ConfigurationPath.Combine(pathSegments);
 
-            return provider.TryGet(key, out var value) ? value : null;
+            if (provider.TryGet(key, out var value))
+            {
+                return value;
+            }
+
+            return null;
         }
 
         public static bool HasKey(this IConfigurationProvider provider, params string[] pathSegments)

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/ConfigurationProviderExtensions.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/ConfigurationProviderExtensions.cs
@@ -9,12 +9,7 @@ namespace Tests
         {
             var key = ConfigurationPath.Combine(pathSegments);
 
-            if (provider.TryGet(key, out var value))
-            {
-                return value;
-            }
-
-            return null;
+            return provider.TryGet(key, out var value) ? value : null;
         }
 
         public static bool HasKey(this IConfigurationProvider provider, params string[] pathSegments)

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -129,7 +129,6 @@ namespace Tests.Internal
             Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.Is<GetSecretValueRequest>(x => x.SecretId.Equals(firstSecretArn)), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
             
             options.SecretFilter = entry => true;
-            options.UseDefinedArnList = true;
             options.DefinedSecretArns = new List<string> {firstSecretArn};
             options.KeyGenerator = (entry, key) => secretKey;
 

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -129,7 +129,7 @@ namespace Tests.Internal
             Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.Is<GetSecretValueRequest>(x => x.SecretId.Equals(firstSecretArn)), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
             
             options.SecretFilter = entry => true;
-            options.DefinedSecretArns = new List<string> {firstSecretArn};
+            options.AcceptedSecretArns = new List<string> {firstSecretArn};
             options.KeyGenerator = (entry, key) => secretKey;
 
             sut.Load();

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -119,6 +120,27 @@ namespace Tests.Internal
 
             Assert.That(sut.Get(testEntry.Name), Is.Null);
         }
+        
+        [Test, CustomAutoData]
+        public void Secrets_can_be_listed_explicitly_and_not_searched([Frozen] SecretListEntry testEntry, ListSecretsResponse listSecretsResponse, GetSecretValueResponse getSecretValueResponse, [Frozen] IAmazonSecretsManager secretsManager, [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut, IFixture fixture)
+        {
+            const string secretKey = "KEY";
+            var firstSecretArn = listSecretsResponse.SecretList.Select(x => x.ARN).First();
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.Is<GetSecretValueRequest>(x => x.SecretId.Equals(firstSecretArn)), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
+            
+            options.SecretFilter = entry => true;
+            options.UseDefinedArnList = true;
+            options.DefinedSecretArns = new List<string> {firstSecretArn};
+            options.KeyGenerator = (entry, key) => secretKey;
+
+            sut.Load();
+
+            Mock.Get(secretsManager).Verify(p => p.GetSecretValueAsync(It.Is<GetSecretValueRequest>(x => !x.SecretId.Equals(firstSecretArn)), It.IsAny<CancellationToken>()), Times.Never);
+            Mock.Get(secretsManager).Verify(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            Assert.That(sut.Get(testEntry.Name), Is.Null);
+            Assert.That(sut.Get(secretKey), Is.EqualTo(getSecretValueResponse.SecretString));
+        }
 
         [Test, CustomAutoData]
         public void Keys_can_be_customized_via_options([Frozen] SecretListEntry testEntry, ListSecretsResponse listSecretsResponse, GetSecretValueResponse getSecretValueResponse, string newKey, [Frozen] IAmazonSecretsManager secretsManager, [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut, IFixture fixture)
@@ -156,7 +178,7 @@ namespace Tests.Internal
 
             Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).Throws(new ResourceNotFoundException("Oops"));
 
-            Assert.That(() => sut.Load(), Throws.TypeOf<MissingSecretValueException>());
+            Assert.That(sut.Load, Throws.TypeOf<MissingSecretValueException>());
         }
 
         [Test, CustomAutoData]


### PR DESCRIPTION
Searching for keys makes the secrets manager configuration require the ListSecrets permission, which some organizations don't like to grant to services. This PR allows users to define a list of secret ARNs to load, and it only loads those. Filtering still works, but I don't see a good reason to use a filter with a defined secrets list.

Test created and passed. Not sure the best way to develop an example