### PR TITLE
Make JSON check more robust

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Kralizek.Extensions.Configuration.Internal
@@ -76,7 +77,19 @@ namespace Kralizek.Extensions.Configuration.Internal
             }
         }
 
-        private static bool IsJson(string str) => str.StartsWith("[") || str.StartsWith("{");
+        private static bool IsJson(string str)
+        {
+            try
+            {
+                _ = JToken.Parse(str);
+
+                return true;
+            }
+            catch (JsonReaderException)
+            {
+                return false;
+            }
+        }
 
         private static IEnumerable<(string key, string value)> ExtractValues(JToken token, string prefix)
         {

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/CustomAutoDataAttribute.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/CustomAutoDataAttribute.cs
@@ -5,15 +5,30 @@ using AutoFixture;
 using AutoFixture.AutoMoq;
 using Kralizek.Extensions.Configuration.Internal;
 using Amazon.SecretsManager.Model;
+using System;
 using System.Collections.Generic;
 
 namespace Tests
 {
+    [AttributeUsage(AttributeTargets.Method)]
     public class CustomAutoDataAttribute : AutoDataAttribute
     {
-        public CustomAutoDataAttribute() : base(CreateFixture) { }
+        public CustomAutoDataAttribute() : base(FixtureHelpers.CreateFixture)
+        {
+        }
+    }
 
-        private static IFixture CreateFixture()
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class CustomInlineAutoDataAttribute : InlineAutoDataAttribute
+    {
+        public CustomInlineAutoDataAttribute(params object[] args) : base(FixtureHelpers.CreateFixture, args)
+        {
+        }
+    }
+
+    public static class FixtureHelpers
+    {
+        public static IFixture CreateFixture()
         {
             IFixture fixture = new Fixture();
 

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -237,5 +237,21 @@ namespace Tests.Internal
             Assert.That(sut.Get(testEntry.Name), Is.EqualTo(getSecretValueUpdatedResponse.SecretString));
         }
         
+        [Test]
+        [Description("Reproduces issue 48")]
+        [CustomInlineAutoData("{THIS IS NOT AN OBJECT}")]
+        [CustomInlineAutoData("[THIS IS NOT AN ARRAY]")]
+        public void Incorrect_json_should_be_processed_as_string(string content, [Frozen] SecretListEntry testEntry, ListSecretsResponse listSecretsResponse, GetSecretValueResponse getSecretValueResponse, [Frozen] IAmazonSecretsManager secretsManager, SecretsManagerConfigurationProvider sut)
+        {
+            getSecretValueResponse.SecretString = content;
+
+            Mock.Get(secretsManager).Setup(p => p.ListSecretsAsync(It.IsAny<ListSecretsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(listSecretsResponse);
+
+            Mock.Get(secretsManager).Setup(p => p.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(getSecretValueResponse);
+
+            sut.Load();
+
+            Assert.That(sut.Get(testEntry.Name), Is.EqualTo(getSecretValueResponse.SecretString));
+        }
     }
 }


### PR DESCRIPTION
- Uses JToken.Parse and catches possible JsonReaderException to detect if given string is a JSON snippet

Fixes #48