### PR TITLE
Feature/improve accepted secret ARNs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This code is also available in [this sample](/samples/Sample1).
 **Note**: the snippets above assume that some [AWS credentials are available by default](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/) to your application. [Here](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html) you can see how to setup your environment.
 
 ## Community posts
+
 * [Secure secrets storage for ASP.NET Core with AWS Secrets Manager (Part 1)](https://andrewlock.net/secure-secrets-storage-for-asp-net-core-with-aws-secrets-manager-part-1/) by Andrew Lock
 * [Secure secrets storage for ASP.NET Core with AWS Secrets Manager (Part 2)](https://andrewlock.net/secure-secrets-storage-for-asp-net-core-with-aws-secrets-manager-part-2/) by Andrew Lock
 * [Useful tools to manage your application's secrets](https://raygun.com/blog/manage-application-secrets/) by Jerrie Pelser
@@ -75,6 +76,7 @@ Here are some samples.
 You can provide your AWS access and secret key directly by using the `BasicAWSCredentials` class.
 
 **Note** You should avoid this. After all, the intent of this library is to remove our secrets from the source code.
+
 ```csharp
 var credentials = new BasicAWSCredentials("my-accessKey", "my-secretKey");
 builder.AddSecretsManager(credentials: credentials);
@@ -85,6 +87,7 @@ builder.AddSecretsManager(credentials: credentials);
 You can use a specific profile by using the `StoredProfileAWSCredentials` class.
 
 **Note** The `StoredProfileAWSCredentials` has been marked as obsolete and will be removed in a later release.
+
 ```csharp
 var credentials = new StoredProfileAWSCredentials("my_profile_name");
 builder.AddSecretsManager(credentials: credentials);
@@ -140,14 +143,17 @@ builder.AddSecretsManager(configurator: options =>
 You can see an example [here](/samples/Sample4).
 
 ### Defining list of secrets in advance (no list secrets permission required)
-Security best practices sometimes prevent the listing of secrets in a production environment. As a result, a defined list of `ARN` can be provided in lieu of a secrets filter. In this case, the library will only retrieve the secrets whose `ARN` are given. The `.SecretFilter` is ignored.
+
+Security best practices sometimes prevent the listing of secrets in a production environment.
+As a result, it is possible to define a list of secrets in lieu of a secret filter. When using this this approach,
+the library will only retrieve the secrets whose `ARN` or name are present in the given `AcceptedSecretArns` list.  
 
 ```csharp
 var acceptedARNs = new[]
 {
-    "MySecretARN1",
-    "MySecretARN2",
-    "MySecretARN3",
+    "MySecretFullARN-abcxyz",
+    "MySecretPartialARN",
+    "MySecretUniqueName",
 };
 
 builder.AddSecretsManager(configurator: options =>
@@ -200,6 +206,7 @@ This project uses [Cake](https://cakebuild.net/) as a build engine.
 If you would like to build this project locally, just execute the `build.cake` script.
 
 You can do it by using the .NET tool created by CAKE authors and use it to execute the build script.
+
 ```powershell
 dotnet tool install -g Cake.Tool
 dotnet cake

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -3,22 +3,95 @@ using System.Collections.Generic;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 
+
 namespace Kralizek.Extensions.Configuration.Internal
 {
     public class SecretsManagerConfigurationProviderOptions
     {
+        /// <summary>
+        /// A list of identifiers for the secrets that are to be retrieved.
+        /// The secret ARN (full or partial) and secret name are supported.
+        /// <remarks>
+        /// See <see cref="GetSecretValueRequest.SecretId"/> for more info on supported values.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// AcceptedSecretArns = new List&lt;string&gt;
+        /// {
+        ///     "MySecretFullARN-abcxyz",
+        ///     "MySecretPartialARN",
+        ///     "MySecretUniqueName"
+        /// };
+        /// </code>
+        /// </example>
+        /// </summary>
         public List<string> AcceptedSecretArns { get; set; } = new();
         
+        /// <summary>
+        /// A function that determines whether or not a given secret should be retrieved.
+        /// </summary>
+        /// <example>
+        /// <code>SecretFilter = secret => secret.Name.Contains("IncludeMe");</code>
+        /// </example>
         public Func<SecretListEntry, bool> SecretFilter { get; set; } = _ => true;
 
+        /// <summary>
+        /// A list of filters that get passed to the client to filter the listed secrets before returning them. 
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// ListSecretsFilters = new List&lt;Filter&gt;
+        /// {
+        ///     new Filter
+        ///     {
+        ///         Key = FilterNameStringType.Name,
+        ///         Values = new List&lt;string&gt; { "IncludeMe" }
+        ///     }
+        /// };
+        /// </code>
+        /// </example>
         public List<Filter> ListSecretsFilters { get; set; } = new();
 
+        /// <summary>
+        /// Defines a function that can be used to generate secret keys.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// KeyGenerator = (secret, key) => key.ToUpper();
+        /// </code>
+        /// </example>
         public Func<SecretListEntry, string, string> KeyGenerator { get; set; } = (secret, key) => key;
 
+        /// <summary>
+        /// A function that can be used to configure the <see cref="AmazonSecretsManagerClient"/>
+        /// that's injected into the client.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// ConfigureSecretsManagerConfig = config => config.Timeout = TimeSpan.FromSeconds(5)
+        /// </code>
+        /// </example>
         public Action<AmazonSecretsManagerConfig> ConfigureSecretsManagerConfig { get; set; } = _ => { };
 
+        /// <summary>
+        /// A function that can be used to provide a custom method to create a client.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// CreateClient = () => new MyCustomSecretsManagerClient();
+        /// </code>
+        /// </example>
         public Func<IAmazonSecretsManager>? CreateClient { get; set; }
 
+        /// <summary>
+        /// The time that should be waited before refreshing the secrets.
+        /// If null, secrets will not be refreshed.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// PollingInterval = TimeSpan.FromMinutes(15);
+        /// </code>
+        /// </example>
         public TimeSpan? PollingInterval { get; set; }
     }
 }


### PR DESCRIPTION
I've updated the README to indicate that the `SecretsManagerConfigurationProviderOptions.AcceptedSecretArns` property can be used to specify the ARN or name of secrets to be fetched. 

Also added some XML comments to the properties in the `SecretsManagerConfigurationProviderOptions` class, along with some examples on how to use properties (e.g. how to use the actions and funcs).

These changes are associated with issue #59 

I havent made package versioning changes. I'm under the impression this is handled by the Cake build. If not, I'd appreciate some advise on what needs done here.