### PR TITLE
Update README to include EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Amazon introduced [IAM roles for service accounts](https://docs.aws.amazon.com/e
 
 However, this feature requires an additional package to be installed which is loaded by reflection.
 
-    dotnet add AWSSDK.SecurityToken
+```powershell
+dotnet add AWSSDK.SecurityToken
+```
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ This code is also available in [this sample](/samples/Sample1).
 * [Useful tools to manage your application's secrets](https://raygun.com/blog/manage-application-secrets/) by Jerrie Pelser
 * [Storing secrets CORRECTLY in .NET using AWS Secrets Manager](https://www.youtube.com/watch?v=BGW4FnEB-CM) by [Nick Chapsas](https://github.com/Elfocrash)
 
+## Amazon Elastic Kubernetes Service (EKS)
+
+In order to authenticate requests to AWS Secret Manager a pod needs to use a IAM role that grants access to your secrets.
+Amazon introduced [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to make this possible without third party solutions.
+
+However, this feature requires an additional package to be installed which is loaded by reflection.
+
+    dotnet add AWSSDK.SecurityToken
+
 ## Customization
 
 This library offers the possibility to customize how the setting values are retrieved from AWS Secrets Manager and added to the Configuration provider.

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Kralizek.Extensions.Configuration</RootNamespace>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.103" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.2.56" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Kralizek.Extensions.Configuration</RootNamespace>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.2.56" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.103" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>


### PR DESCRIPTION
The IAM roles for Service Accounts feature was added to allow EKS pods to talk to AWS Secret Manager using a Service Account. This allows roles to be used natively in EKS.
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html

However, the library was using a very old version of the AWS SDK that did not support this.

I wasn't quite sure if I should go with the lowest version where this feature was added or the latest SDK. I am open to feedback and can alter the PR if necessary. 

It is kind of hard to backtrack to what exact version of `AWSSDK.SecretsManager` is the minimum version as they only list the minimum SDK version which is not on the same version numbers. https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html

I also tried to provide some guidance on the EKS side of things as an additional library is required.