### PR TITLE
Implementation of Batch fetch via feature toggle.

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SecretsManager;
@@ -9,7 +8,6 @@ using Amazon.SecretsManager.Model;
 using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using Amazon.Runtime;
-using Amazon.SecretsManager.Model.Internal.MarshallTransformations;
 
 
 namespace Kralizek.Extensions.Configuration.Internal

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProvider.cs
@@ -372,15 +372,24 @@ namespace Kralizek.Extensions.Configuration.Internal
             {
                 return errorResponse.ErrorCode switch
                 {
-                    "DecryptionFailure" => new DecryptionFailureException(errorResponse.Message),
-                    "InternalServiceError" => new InternalServiceErrorException(errorResponse.Message),
-                    "InvalidParameterException" => new InvalidParameterException(errorResponse.Message),
-                    "InvalidRequestException" => new InvalidRequestException(errorResponse.Message),
+                    "DecryptionFailure" => new DecryptionFailureException(errorResponse.Message, ErrorType.Unknown,
+                        errorResponse.ErrorCode, secretValueSet.ResponseMetadata.RequestId,
+                        secretValueSet.HttpStatusCode),
+                    "InternalServiceError" => new InternalServiceErrorException(errorResponse.Message,
+                        ErrorType.Unknown, errorResponse.ErrorCode, secretValueSet.ResponseMetadata.RequestId,
+                        secretValueSet.HttpStatusCode),
+                    "InvalidParameterException" => new InvalidParameterException(errorResponse.Message,
+                        ErrorType.Unknown, errorResponse.ErrorCode, secretValueSet.ResponseMetadata.RequestId,
+                        secretValueSet.HttpStatusCode),
+                    "InvalidRequestException" => new InvalidRequestException(errorResponse.Message, ErrorType.Unknown,
+                        errorResponse.ErrorCode, secretValueSet.ResponseMetadata.RequestId,
+                        secretValueSet.HttpStatusCode),
                     "ResourceNotFoundException" => new MissingSecretValueException(errorResponse.Message,
                         errorResponse.SecretId, errorResponse.SecretId,
-                        new ResourceNotFoundException(errorResponse.Message)),
+                        new ResourceNotFoundException(errorResponse.Message, ErrorType.Unknown, errorResponse.ErrorCode,
+                            secretValueSet.ResponseMetadata.RequestId, secretValueSet.HttpStatusCode)),
                     _ => new AmazonServiceException(errorResponse.Message, ErrorType.Unknown, errorResponse.ErrorCode,
-                        "UNKNONWN", HttpStatusCode.Ambiguous)
+                        secretValueSet.ResponseMetadata.RequestId, secretValueSet.HttpStatusCode)
                 };
             }).ToList();
             return set;

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -119,6 +119,8 @@ namespace Kralizek.Extensions.Configuration.Internal
         /// If True, Requests will use BatchGetSecretValue to retrieve up to 20 secrets at a time.
         /// If set to true, <see cref="ConfigureSecretValueRequest"/> will no longer work,
         /// you must instead use <see cref="ConfigureBatchSecretValueRequest"/>
+        /// <para/>
+        /// Note: You must make sure secretsmanager:BatchGetSecretValue is allowed for the resource!
         /// </summary>
         public bool UseBatchFetch { get; set; }
     }

--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Internal/SecretsManagerConfigurationProviderOptions.cs
@@ -63,6 +63,7 @@ namespace Kralizek.Extensions.Configuration.Internal
 
         /// <summary>
         /// Defines a function that can be used to customize the <see cref="GetSecretValueRequest"/> before it is sent.
+        /// This Option is only used if <see cref="UseBatchFetch"/> is set to false.
         /// </summary>
         /// <example>
         /// <code>
@@ -70,6 +71,17 @@ namespace Kralizek.Extensions.Configuration.Internal
         /// </code>
         /// </example>
         public Action<GetSecretValueRequest, SecretValueContext> ConfigureSecretValueRequest { get; set; } = (_, _) => { };
+        
+        /// <summary>
+        /// Defines a function that can be used to customize the <see cref="BatchGetSecretValueRequest"/> before it is sent.
+        /// This Option is only used if <see cref="UseBatchFetch"/> is set to true.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// ConfigureSecretValueRequest = (request, context) => request.VersionStage = "AWSCURRENT";
+        /// </code>
+        /// </example>
+        public Action<BatchGetSecretValueRequest, List<SecretValueContext>> ConfigureBatchSecretValueRequest { get; set; } = (_, _) => { };
 
         /// <summary>
         /// A function that can be used to configure the <see cref="AmazonSecretsManagerClient"/>
@@ -102,5 +114,12 @@ namespace Kralizek.Extensions.Configuration.Internal
         /// </code>
         /// </example>
         public TimeSpan? PollingInterval { get; set; }
+
+        /// <summary>
+        /// If True, Requests will use BatchGetSecretValue to retrieve up to 20 secrets at a time.
+        /// If set to true, <see cref="ConfigureSecretValueRequest"/> will no longer work,
+        /// you must instead use <see cref="ConfigureBatchSecretValueRequest"/>
+        /// </summary>
+        public bool UseBatchFetch { get; set; }
     }
 }


### PR DESCRIPTION
~~(Will edit title if this is acceptable to see through to completion and I switch from draft)~~

Proposal for resolving #95 

Basically, via options toggle, we can let users opt-in to batch fetch requests. This can be especially helpful for use cases where lots of secrets are involved and refreshes are enabled to minimize API calls and improve overall load times.

I will note some of this implementation is naive/paranoid, AWS Batch fetches can sometimes have vexing behavior so I coded this POC defensively based on experiences with other services batch calls.

There's also opportunity for some code consolidation, but in my head this makes for easier diff.