### PR TITLE
AWS SDK v4 Support

### DIFF
--- a/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
+++ b/src/Kralizek.Extensions.Configuration.AWSSecretsManager/Kralizek.Extensions.Configuration.AWSSecretsManager.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="[3.7.400.86,4)" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="[4.0.0,5)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>


### PR DESCRIPTION
AWS SDK v4 is out now.
It seems to be source-compatible with this library, but isn't binary compatible (You get `Unhandled exception. System.MissingMethodException: Method not found: 'System.DateTime Amazon.SecretsManager.Model.GetSecretValueResponse.get_CreatedDate()'.`).

Using this fork in one of our projects now - so thought I'd make a PR in case it's helpful. :) 