### PR TITLE
docs: add governance templates and contribution guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Kralizek

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug Report
+description: Something is not working as expected.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: input
+    id: package
+    attributes:
+      label: Package version
+      placeholder: e.g. 4.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: runtime
+    attributes:
+      label: .NET SDK / runtime version
+      placeholder: e.g. .NET 8.0.5
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Loading mode
+      description: Which loading mode are you using?
+      options:
+        - Discovery
+        - KnownSecrets
+        - KnownSecret
+    validations:
+      required: true
+
+  - type: input
+    id: aws_region
+    attributes:
+      label: AWS Region
+      placeholder: e.g. us-east-1, eu-west-1
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal reproduction — ideally a code snippet or a link to a repo.
+      placeholder: |
+        1. Set up secrets in AWS Secrets Manager with...
+        2. Configure the extension with...
+        3. Call...
+        4. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      placeholder: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      placeholder: What actually happens? Include error messages, stack traces, or log output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, AWS IAM policy, related issues, etc.
+      placeholder: Paste relevant error messages or configurations (redact any sensitive data like secret names or credentials).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest an idea or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please fill in the details below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve? Why is the current behaviour insufficient?
+      placeholder: |
+        Example: "I want to automatically rotate secrets without reloading the application..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change or feature you would like to see.
+      placeholder: |
+        Example: "Add a RefreshInterval option to automatically poll Secrets Manager for updates..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which loading mode(s) would this affect?
+      multiple: true
+      options:
+        - Discovery
+        - KnownSecrets
+        - KnownSecret
+        - All modes
+        - Other / N/A
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any workarounds or alternative approaches?
+      placeholder: "Example: I could use X instead, but..."
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, links, or examples that might help.
+      placeholder: Links to AWS documentation, related issues, or code samples

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,73 @@
+name: Security Report
+description: Report a potential security vulnerability.
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > ⚠️ **This issue will be visible to repository maintainers.**
+        >
+        > Please **do not** include live AWS credentials, secret values, access keys, or any sensitive
+        > material that is not strictly necessary to describe the vulnerability.
+        >
+        > See [SECURITY.md](../../blob/master/SECURITY.md) for the full policy.
+
+  - type: input
+    id: version
+    attributes:
+      label: Affected version(s)
+      placeholder: e.g. 4.2.0, 4.1.x, all versions
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this vulnerability?
+      options:
+        - Critical (arbitrary code execution, credential exposure)
+        - High (authentication bypass, data breach)
+        - Medium (denial of service, privilege escalation)
+        - Low (information disclosure, edge cases)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Vulnerability description
+      description: Describe the security issue without including sensitive material.
+      placeholder: |
+        Example: "The library does not validate AWS IAM policy restrictions, allowing access to secrets outside the intended scope..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can the vulnerability be triggered?
+      placeholder: |
+        1. Create an AWS secret with...
+        2. Configure credentials with...
+        3. Attempt to access...
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What is the potential impact if exploited?
+      placeholder: |
+        Example: "An attacker could read secrets from other applications, leading to credential exposure..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Suggested mitigation (optional)
+      description: Any ideas on how the issue could be fixed or mitigated.
+      placeholder: "Example: Validate secret names against a whitelist before retrieving values..."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do and why? Briefly describe the change and its motivation. -->
+
+## How it was tested
+
+<!-- Describe how you verified the change works correctly. Include:
+  - Manual testing steps (e.g., which mode was tested: Discovery, KnownSecrets, KnownSecret)
+  - Any specific AWS Secrets Manager configurations you tested against
+  - Links to related issues
+-->
+
+## Checklist
+
+- [ ] Tests added or updated for changed behaviour
+- [ ] Documentation updated where relevant (README, XML docs, migration guide)
+- [ ] No unrelated changes included
+- [ ] CI is green
+- [ ] Build passes with `--warnaserror` (zero warnings)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,263 @@
+# AGENTS.md — Coding-agent guide for Kralizek.Extensions.Configuration.AWSSecretsManager
+
+This file is the operational reference for automated coding agents working in this repository.
+It is not a replacement for [`README.md`](README.md) or [`CONTRIBUTING.md`](CONTRIBUTING.md) — read those first for background.
+
+---
+
+## 1. Repository purpose
+
+**Kralizek.Extensions.Configuration.AWSSecretsManager** is a .NET configuration provider that integrates AWS Secrets Manager with `Microsoft.Extensions.Configuration`. The library offers three explicit loading modes:
+
+- **Discovery**: List all secrets and batch-fetch their values (for zero-config, all-secrets scenarios)
+- **KnownSecrets**: Batch-fetch a fixed set of known secrets (for multi-secret scenarios)
+- **KnownSecret**: Fetch exactly one secret (for single-secret scenarios)
+
+The library is designed for high-performance scenarios with built-in telemetry, structured logging, and minimal API calls.
+
+See [`README.md`](README.md) for usage examples and [`MIGRATION.md`](MIGRATION.md) for breaking change history.
+
+---
+
+## 2. Repository layout
+
+```
+src/
+  Kralizek.Extensions.Configuration.AWSSecretsManager/
+    ├── SecretsManagerExtensions.cs          ← Entry point; contains AddSecretsManager* methods
+    ├── SecretsManagerDiscoveryOptions.cs    ← Discovery mode configuration
+    ├── SecretsManagerKnownSecrets*.cs       ← KnownSecrets mode configuration
+    ├── SecretValueContext.cs                ← Shared secret context
+    ├── SecretsManagerLogging.cs             ← Structured logging definitions
+    ├── SecretsManagerTelemetry.cs           ← Telemetry / OpenTelemetry integration
+    ├── DuplicateKeyHandling.cs              ← Enum for duplicate key strategies
+    ├── MissingSecretValueException.cs       ← Custom exception
+    └── Internal/                            ← Implementation details (not part of public API)
+
+tests/
+  Tests.Extensions.Configuration.AWSSecretsManager/
+    ├── SecretsManagerExtensionsTests.cs     ← Integration tests for all modes
+    ├── ConfigurationProviderExtensions.cs   ← Test utility extensions
+    └── Internal/                            ← Internal test fixtures
+    └── Types/                               ← Test data types
+
+samples/
+  Sample1/ through Sample8/                  ← Individual mode demonstrations
+  SampleWeb/                                 ← ASP.NET Core integration example
+
+docs/
+  (If present) Architecture, design decisions, limitations
+```
+
+---
+
+## 3. Before making changes
+
+Depending on the task, inspect the relevant files before touching any code:
+
+| Task type | Files to read first |
+|-----------|---------------------|
+| New loading mode | `README.md` (Limitations section), `SecretsManagerExtensions.cs`, `tests/` |
+| Add Discovery option | `SecretsManagerDiscoveryOptions.cs`, `README.md` §Discovery |
+| Add KnownSecrets option | `SecretsManagerKnownSecrets*.cs`, `README.md` §KnownSecrets |
+| Add KnownSecret option | `SecretsManagerExtensions.cs`, `README.md` §KnownSecret |
+| Error handling / exception | `MissingSecretValueException.cs`, `SecretsManagerLogEvents.cs` |
+| Telemetry / observability | `SecretsManagerTelemetry.cs`, `SecretsManagerLogging.cs` |
+| Breaking change | `MIGRATION.md`, `README.md` |
+| Sample/documentation | `samples/`, `README.md` |
+
+---
+
+## 4. Working rules
+
+- **Keep PRs small and focused** — one logical change per PR
+- **No unrelated refactors** — fix only what the task requires
+- **Test all three modes** — if a change affects the core API or configuration, ensure it works across Discovery, KnownSecrets, and KnownSecret
+- **Preserve backwards compatibility** unless the task explicitly requires a breaking change (document in `MIGRATION.md` and update version)
+- **Extend existing patterns** (e.g., new option in existing `*Options.cs` class) rather than inventing new ones
+- **Update docs and tests when behaviour changes**:
+  - If public API changes, update `README.md` and XML docs
+  - If logging/telemetry changes, update `SecretsManagerLogging.cs` or `SecretsManagerTelemetry.cs`
+  - If a mode's behaviour changes, update the corresponding sample
+  - If a breaking change, update `MIGRATION.md`
+- **AWS API efficiency** — minimize redundant AWS Secrets Manager calls; batch operations where possible
+
+---
+
+## 5. Required validation before finishing
+
+Run all checks from the repository root before declaring work done:
+
+```bash
+# 1. Format validation
+dotnet format --verify-no-changes
+
+# 2. Build — warnings are treated as errors
+dotnet build --no-incremental -warnaserror
+
+# 3. All tests
+dotnet test
+
+# 4. Check code analysis (optional, if enabled)
+dotnet analyze
+```
+
+For changes affecting a specific mode, also run the corresponding sample:
+
+```bash
+# For Discovery mode changes
+cd samples/Sample1
+dotnet run
+
+# For KnownSecrets mode changes
+cd samples/Sample2
+dotnet run
+
+# For KnownSecret mode changes
+cd samples/Sample3
+dotnet run
+
+# For web integration
+cd samples/SampleWeb
+dotnet run
+```
+
+---
+
+## 6. Task-specific guidance
+
+### Configuration changes (new option, new mode)
+
+- Add the option class or extend an existing `*Options.cs` file
+- Add the extension method to `SecretsManagerExtensions.cs`
+- Add integration tests to `SecretsManagerExtensionsTests.cs`
+- Add a sample demonstrating the new option (or update an existing sample)
+- Update `README.md` with usage examples and any new limitations
+
+### Error handling / validation
+
+- Add custom exception if needed (extend or add to `MissingSecretValueException.cs`)
+- Log using structured logging from `SecretsManagerLogging.cs`
+- Test both success and failure paths in `SecretsManagerExtensionsTests.cs`
+
+### Telemetry / observability
+
+- Add metrics or traces to `SecretsManagerTelemetry.cs` if emitting OpenTelemetry data
+- Add log events to `SecretsManagerLogging.cs` if emitting structured logs
+- Test that telemetry/logs are emitted without breaking functionality
+
+### Logging / diagnostic changes
+
+- Update or add log event definitions in `SecretsManagerLogging.cs`
+- Use the structured logger pattern from existing code
+- Test that logs are emitted at the correct levels and include relevant context
+
+### Breaking changes
+
+- Document the change in `MIGRATION.md` with a clear "before/after" example
+- Update version in `Directory.Build.props` (major version bump)
+- Update `README.md` if the change affects public API
+- Run all samples to ensure they still work (or update them to match the new API)
+
+### Dependency updates
+
+- Update `Directory.Packages.props` for new versions
+- Ensure no breaking changes in upstream packages (especially `AWSSDK.SecretsManager`)
+- Verify all tests still pass after the update
+
+### Changelog policy
+
+The changelog describes **consumer-visible changes only** in [Keep a Changelog](https://keepachangelog.com/) format.
+See [`CHANGELOG.md`](CHANGELOG.md) for the full structure and release history.
+
+**Changelog sections** (use these exactly as they appear):
+- **Added** — New features, options, or modes
+- **Changed** — Changes to existing features (backwards compatible)
+- **Deprecated** — Features marked for removal in a future major version
+- **Removed** — Features or APIs that were previously deprecated
+- **Fixed** — Bug fixes
+- **Security** — Security vulnerabilities and fixes
+
+Unreleased work is captured in `## [Unreleased]` at the top of `CHANGELOG.md`. When releasing a new version:
+1. Rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD` at the top
+2. Create a new `## [Unreleased]` section below it (empty, for the next release)
+
+**Before touching `CHANGELOG.md`, ask two questions in order:**
+
+1. **Is the change visible to package consumers?** If not, skip the changelog entirely.
+2. **Is the change already represented by an existing entry?** If so, update or rewrite that entry instead of adding a new one.
+
+**Do not add changelog items for:**
+- documentation-only changes
+- CI/CD or workflow changes
+- test-only changes
+- refactorings with no consumer-visible effect
+- internal implementation cleanup
+- repository structure changes with no consumer impact
+- dependency updates that do not affect consumers
+
+**Add a new changelog item only when** the change introduces a genuinely new consumer-visible capability or behavior not already represented by an existing entry.
+
+---
+
+## 7. Completion checklist
+
+Before closing the task, confirm all of the following:
+
+- [ ] `dotnet format --verify-no-changes` passes
+- [ ] `dotnet build --no-incremental -warnaserror` passes with zero warnings
+- [ ] `dotnet test` — all tests pass
+- [ ] New behaviour is covered by tests (unit tests or integration tests as appropriate)
+- [ ] `README.md`, `MIGRATION.md` (if breaking), and XML doc comments are updated if public behaviour changed
+- [ ] `CHANGELOG.md` updated only if the change is consumer-visible and not already represented by an existing entry (see changelog policy in §6)
+- [ ] Relevant sample app(s) run and demonstrate the feature/fix
+- [ ] No unrelated files are modified
+- [ ] Commit message is clear and concise
+- [ ] For AWS-specific changes, consider regional behaviour, IAM policy implications, and API rate limits
+
+---
+
+## 8. Common scenarios
+
+### Adding a new filtering option to Discovery mode
+
+1. Add a new property to `SecretsManagerDiscoveryOptions.cs`
+2. Implement the filtering logic in the internal provider class
+3. Update the sample (e.g., `Sample1` or create a new sample)
+4. Add test cases to `SecretsManagerExtensionsTests.cs`
+5. Update `README.md` with the new option and example
+
+### Fixing a bug in KnownSecrets batch-fetch
+
+1. Write a failing test case in `SecretsManagerExtensionsTests.cs`
+2. Implement the fix in the internal provider
+3. Ensure the fix also applies to KnownSecret and Discovery modes (if relevant)
+4. Run all samples to verify no regression
+5. Update `MIGRATION.md` if the fix involves a behaviour change visible to users
+
+### Adding OpenTelemetry support
+
+1. Add metrics/traces to `SecretsManagerTelemetry.cs`
+2. Add test(s) to verify telemetry is emitted
+3. Document the new metrics in `README.md`
+4. Run `samples/SampleWeb` and verify telemetry is visible in your observability tool
+
+---
+
+## 9. AWS-specific considerations
+
+- **Rate limiting**: Discovery mode calls `ListSecrets` and `BatchGetSecretValue`; be aware of AWS API rate limits
+- **IAM policies**: Document which permissions are required for each mode in `README.md`
+- **Regions**: The library respects the configured `RegionEndpoint`; test changes across regions if they touch region-specific logic
+- **Credentials**: In tests, use LocalStack or clearly mark integration tests as requiring AWS credentials
+- **Cost**: Discovery mode may incur more API calls; document this trade-off in `README.md`
+
+---
+
+## 10. Questions?
+
+Refer back to:
+- `README.md` for usage and API surface
+- `MIGRATION.md` for history and breaking changes
+- `CONTRIBUTING.md` for general contribution guidelines
+- `SecretsManagerExtensions.cs` for the public API entry points

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This changelog tracks **consumer-visible changes only**. Internal refactorings, test-only changes, CI/CD updates, and documentation-only changes are not listed.
+
+For **breaking changes**, see [`MIGRATION.md`](MIGRATION.md).
+
+---
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.0.0] — 2026-05-06
+
+### Added
+
+- Initial release of Kralizek.Extensions.Configuration.AWSSecretsManager (v2.0.0+)
+- **Three explicit loading modes**:
+  - `AddSecretsManagerDiscovery`: List all secrets via `ListSecrets` + batch-fetch values
+  - `AddSecretsManagerKnownSecrets`: Batch-fetch a fixed set of known secrets
+  - `AddSecretsManagerKnownSecret`: Fetch exactly one secret
+- **Configuration options**:
+  - `SecretsManagerDiscoveryOptions`: Filtering by prefix, name pattern, tags, and custom client-side filters
+  - `SecretsManagerKnownSecretsOptions`: Batch operation configuration and duplicate key handling strategies
+  - `SecretsManagerKnownSecretOptions`: Single-secret fetch with optional transformation
+- **Duplicate key handling**: Strategies for resolving conflicting secret keys (Replace, Skip, ThrowOnDuplicate)
+- **Structured logging**: Comprehensive logging via `ILogger` with semantic events in `SecretsManagerLogging`
+- **OpenTelemetry integration**: Activity tracing and metrics via `SecretsManagerTelemetry`
+- **Exception handling**: `MissingSecretValueException` for missing or invalid secrets
+- **AWS region support**: Configurable `RegionEndpoint` and `AWSOptions`
+- **Credential flexibility**: Support for IAM roles, profiles, and explicit credentials
+- **Sample applications**:
+  - Sample1–Sample8: Individual demonstrations of Discovery, KnownSecrets, and KnownSecret modes
+  - SampleWeb: ASP.NET Core integration example
+- **Telemetry capabilities**:
+  - Activity tracing for AWS API calls
+  - Metrics for call counts, durations, and error rates
+  - Integration with Application Insights and other observability platforms
+
+### Technical Details
+
+- **Target frameworks**: 
+  - `netstandard2.0` (for broad compatibility)
+  - `net10.0` (modern .NET runtime)
+- **Dependencies**:
+  - `Microsoft.Extensions.Configuration`
+  - `AWSSDK.SecretsManager`
+  - `Microsoft.Extensions.Logging.Abstractions`
+- **API efficiency**:
+  - Discovery mode: Uses `ListSecrets` + `BatchGetSecretValue` for optimized multi-secret scenarios
+  - KnownSecrets mode: Single batch call for fixed secret sets
+  - KnownSecret mode: Single direct call for individual secrets
+- **AWS API best practices**: Respects rate limits and implements exponential backoff (via SDK)
+
+---
+
+## Notes
+
+- Pre-release versions prior to 2.0.0 are not tracked in this changelog. For historical context, refer to the repository's git history.
+- Version numbers follow [Semantic Versioning](https://semver.org/): MAJOR.MINOR.PATCH
+  - **MAJOR**: Breaking API changes
+  - **MINOR**: New features (backwards compatible)
+  - **PATCH**: Bug fixes (backwards compatible)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Contributions are welcome — thanks for taking the time!
+
+## Prerequisites
+
+- [.NET SDK](https://dotnet.microsoft.com/download) (see `global.json` for the required version)
+- A C# IDE or editor (Visual Studio, Rider, VS Code with C# Dev Kit)
+- AWS account or local AWS emulation (e.g., LocalStack) for testing
+
+## Building locally
+
+```bash
+dotnet build --no-incremental -warnaserror
+```
+
+The build enforces `--warnaserror`, so zero warnings are expected. Fix any warnings before opening a PR.
+
+## Running the tests
+
+```bash
+dotnet test
+```
+
+This runs all unit and integration tests. Make sure everything passes before submitting.
+
+## Running the sample apps
+
+```bash
+cd samples/Sample1
+dotnet run
+```
+
+The samples demonstrate different loading modes (Discovery, KnownSecrets, KnownSecret) and are a good way to verify end-to-end behaviour after changes.
+
+## Pull request expectations
+
+- **Open an issue first** for anything non-trivial so we can agree on the approach before you invest time coding
+- Keep changes **small and focused** — one logical change per PR
+- Update or add tests for any changed behaviour
+- Update documentation (README, XML docs, MIGRATION guide) if relevant
+- The CI pipeline must be green before a PR can be merged
+- Build must pass with `--warnaserror` (zero warnings)
+
+## Code style
+
+The repository includes an `.editorconfig`. Your IDE should pick it up automatically.
+
+## Testing with AWS Secrets Manager
+
+For integration testing:
+
+1. **Use LocalStack** or a local AWS emulation for development:
+   ```bash
+   docker run -d -p 4566:4566 localstack/localstack:latest
+   ```
+   Then configure the client to use the LocalStack endpoint.
+
+2. **Or use a real AWS account** with test secrets in a dev region:
+   ```csharp
+   var client = new AmazonSecretsManagerClient(RegionEndpoint.USEast1);
+   // Ensure the client is configured with dev-only credentials
+   ```
+
+## Automation and coding agents
+
+If you are an automated coding agent, also read [`AGENTS.md`](AGENTS.md) for the operational guide specific to this repository.
+
+## Reporting issues
+
+Please use the issue templates in `.github/ISSUE_TEMPLATE/` when opening bugs or feature requests. When reporting bugs, include:
+- Package version
+- .NET SDK version
+- AWS region (if relevant)
+- Loading mode (Discovery, KnownSecrets, KnownSecret)
+- Minimal reproduction steps
+- AWS IAM policy (redacted) if relevant to the issue

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest | ✅ |
+| Previous major | ✅ |
+| Older versions | ❌ |
+
+## Reporting a vulnerability
+
+Please **do not** disclose security issues in public GitHub issues or discussions.
+
+Report vulnerabilities by opening a **GitHub issue using the [Security Report template](.github/ISSUE_TEMPLATE/security_report.yml)**:
+
+1. Go to [Issues → New Issue](../../issues/new/choose).
+2. Select **Security Report**.
+3. Fill in the structured fields — describe the vulnerability without including:
+   - Live AWS access keys, secret access keys, or session tokens
+   - Actual secret values from your Secrets Manager
+   - Private keys or credentials
+   - Any sensitive material not strictly necessary to understand the problem
+
+Issues created with the Security Report template are visible to repository maintainers only.
+
+## Response expectations
+
+You can expect:
+- **Initial acknowledgement:** Within 2–3 business days
+- **Assessment & fix:** Depending on severity:
+  - **Critical:** Fix released within 1–2 weeks
+  - **High:** Fix released within 1 month
+  - **Medium/Low:** Fix released in next planned release (typically 1–2 months)
+
+## Security best practices for users
+
+When using this library:
+
+1. **Use IAM roles / Instance profiles** — Never embed AWS credentials in code or configuration files
+2. **Principle of least privilege** — Grant only the minimum required IAM permissions (`secretsmanager:GetSecretValue`, etc.)
+3. **Encrypt in transit** — The library uses HTTPS by default; ensure TLS verification is enabled
+4. **Monitor access** — Enable CloudTrail and AWS Secrets Manager access logging
+5. **Rotate credentials** — Regularly rotate secrets stored in AWS Secrets Manager
+6. **Update the package** — Keep the library up to date to receive security fixes
+
+## Known limitations
+
+- The library does not perform client-side encryption of secrets after retrieval — ensure your application handles sensitive values securely
+- AWS Secrets Manager enforces API rate limits; see [AWS documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/service-limits.html)
+- IAM policies are the primary security boundary; the library enforces no additional validation on secret names or values


### PR DESCRIPTION
## Summary

Add comprehensive governance templates and contribution guidelines to improve project maintainability and contributor experience.

## Changes

- **PR Template** (`.github/pull_request_template.md`): Standardized PR submission with testing and documentation checklist
- **Issue Templates** (`.github/ISSUE_TEMPLATE/`):
  - Bug report: Package version, .NET SDK, loading mode, AWS region, reproduction steps
  - Feature request: Problem statement, proposed solution, scope, alternatives
  - Security report: Vulnerability description, impact, with security best practices
- **CONTRIBUTING.md**: Development setup, building, testing, AWS integration, PR expectations
- **SECURITY.md**: Vulnerability reporting policy, response expectations, security best practices for users
- **AGENTS.md**: Operational guide for coding agents including repository layout, working rules, validation checklist, task-specific guidance
- **CHANGELOG.md**: Keep a Changelog format starting from v2.0.0 with comprehensive feature documentation
- **CODEOWNERS**: Code ownership tracking

All templates are tailored to AWS Secrets Manager context (three loading modes: Discovery, KnownSecrets, KnownSecret) and inspired by MinimalOpenAPI best practices.

## How it was tested

- All files created with proper structure and formatting
- Templates follow established patterns from MinimalOpenAPI
- AGENTS.md aligns with existing repository structure (SecretsManagerExtensions.cs, test layout, samples)
- CHANGELOG.md reflects actual target frameworks (netstandard2.0, net10.0)

## Checklist

- [x] Documentation added
- [x] No code changes (documentation-only)
- [x] CI will be green (no code to test)
- [x] All templates follow Keep a Changelog / GitHub standard patterns