### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: wednesday
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: "/.github"
     schedule:
       interval: weekly
+      day: wednesday


### PR DESCRIPTION
Groups all NuGet dependency updates into a single Dependabot PR and schedules both NuGet and GitHub Actions update checks weekly on Wednesdays.

GitHub Actions updates remain separate and are scoped to `/.github`.