### PR TITLE
Align CI and NuGet publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,34 +5,49 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  CONFIGURATION: Release
 
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v5
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Restore
         run: dotnet restore
 
       - name: Format Check
-        run: dotnet format --verify-no-changes
+        run: dotnet format --verify-no-changes --no-restore
 
       - name: Build
-        run: dotnet build --no-restore -c Release -warnaserror
+        run: dotnet build --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Test
-        run: dotnet test --no-build -c Release
+        run: dotnet test --configuration $CONFIGURATION --no-build --logger GitHubActions
 
       - name: Pack
-        run: dotnet pack --no-build -c Release
+        run: dotnet pack --configuration $CONFIGURATION --no-build --output ./artifacts/packages
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-packages
+          path: |
+            ./artifacts/packages/*.nupkg
+            ./artifacts/packages/*.snupkg
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet build --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Test
-        run: dotnet test --configuration $CONFIGURATION --no-build
+        run: dotnet test --configuration $CONFIGURATION --no-build --logger GitHubActions
 
       - name: Pack
         run: dotnet pack --configuration $CONFIGURATION --no-build --output ./artifacts/packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet build --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Test
-        run: dotnet test --configuration $CONFIGURATION --no-build --logger GitHubActions
+        run: dotnet test --configuration $CONFIGURATION --no-build
 
       - name: Pack
         run: dotnet pack --configuration $CONFIGURATION --no-build --output ./artifacts/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,50 +7,93 @@ on:
 
 permissions:
   contents: write
+  packages: write
   id-token: write
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  CONFIGURATION: Release
 
 jobs:
   release:
     name: Build and Publish
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v5
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Restore
         run: dotnet restore
 
+      - name: Format Check
+        run: dotnet format --verify-no-changes --no-restore
+
       - name: Build
-        run: dotnet build --no-restore -c Release -warnaserror
+        run: dotnet build --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Test
-        run: dotnet test --no-build -c Release
+        run: dotnet test --configuration $CONFIGURATION --no-build --logger GitHubActions
 
       - name: Pack
-        run: dotnet pack --no-restore -c Release -o ./artifacts
+        run: dotnet pack --configuration $CONFIGURATION --no-build --output ./artifacts/packages
 
-      - name: List packages
-        run: ls -la ./artifacts
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-packages
+          path: |
+            ./artifacts/packages/*.nupkg
+            ./artifacts/packages/*.snupkg
+          if-no-files-found: error
+
+      - name: Configure GitHub Packages source
+        if: github.event_name == 'release'
+        run: >-
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          --name github
+          --username "${{ github.actor }}"
+          --password "${{ github.token }}"
+          --store-password-in-clear-text
+
+      - name: Publish to GitHub Packages
+        if: github.event_name == 'release'
+        run: >-
+          dotnet nuget push
+          "./artifacts/packages/*.nupkg"
+          --source github
+          --api-key "${{ github.token }}"
+          --skip-duplicate
 
       - name: NuGet Login
         if: github.event_name == 'release'
         id: nuget-login
         uses: nuget/login@v1
         with:
-          user: Kralizek       
+          user: Kralizek
 
-      - name: Publish to NuGet
+      - name: Publish to NuGet.org
         if: github.event_name == 'release'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: >-
+          dotnet nuget push
+          "./artifacts/packages/*.nupkg"
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate
 
-      - name: Add to release
+      - name: Add packages to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            ./artifacts/*.nupkg
+            ./artifacts/packages/*.nupkg
+            ./artifacts/packages/*.snupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: dotnet build --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Test
-        run: dotnet test --configuration $CONFIGURATION --no-build --logger GitHubActions
+        run: dotnet test --configuration $CONFIGURATION --no-build
 
       - name: Pack
         run: dotnet pack --configuration $CONFIGURATION --no-build --output ./artifacts/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: dotnet build --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Test
-        run: dotnet test --configuration $CONFIGURATION --no-build
+        run: dotnet test --configuration $CONFIGURATION --no-build --logger GitHubActions
 
       - name: Pack
         run: dotnet pack --configuration $CONFIGURATION --no-build --output ./artifacts/packages

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/tests/Tests.Extensions.Configuration.AWSSecretsManager/Tests.Extensions.Configuration.AWSSecretsManager.csproj
+++ b/tests/Tests.Extensions.Configuration.AWSSecretsManager/Tests.Extensions.Configuration.AWSSecretsManager.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />


### PR DESCRIPTION
## Summary

Aligns the existing Secrets Manager Configuration Provider CI/release setup with the newer package publishing conventions without changing the library itself.

- adds `global.json` so local builds and CI share an SDK policy
- updates checkout/setup-dotnet actions and consumes `global.json`
- keeps NuGet Trusted Publishing via OIDC
- adds GitHub Packages publishing for releases
- uploads `.nupkg` / `.snupkg` files as workflow artifacts and release assets
- runs formatting, build, and tests before packing/publishing

Manual release-workflow runs continue to validate and pack only; NuGet/GitHub publication remains release-triggered.